### PR TITLE
PRO-2475: reset update switch after use

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You should get a response similar to this:
   {"status":"UP","diskSpace":{"status":"UP","total":249644974080,"free":137188298752,"threshold":10485760}}
 ```
 
-## Setting up the ccd database and roles locally
+## Setting up the ccd with roles locally
 
 Follow these instructions to setup data on ccd for Sols - using the latest definition (xls)
 
@@ -141,7 +141,7 @@ change the endpoint host on any sols callbacks to use this ip address in the def
 ### Start up
 launch the all the containers
 ```bash
-docker-compose up
+docker-compose -f docker/docker-compose-with-ccd.yml up
 ```
 
 ### Roles
@@ -158,31 +158,35 @@ import the amended definition
 ```bash
 ./bin/ccd-import-definition.sh "../CCD_Probate_V11.1-Dev.xlsx"
 ```
-Make sure you update the caseEvents tab, cell S1 to be local and update the ip address in T1
-The copy the fields as instructed on the next row of the spreadsheet
-
-### User token
-grab a user token from the out of
-```bash
-./bin/idam-login.sh ProbateSolicitor1@gmail.com
-```
+Make sure you update the caseEvents tab, cell S1 to be local and update the ip address in T1  
+The copy the fields as instructed on the next row of the spreadsheet  
+Also update the PrintableDocumentsUrl in the caseType tab on the spreadsheet in the same manner
 
 ### Go to ccd web app
 ```
-http://localhost:3451/?jwt=<user-token>
+http://localhost:3451/
 ```
 
 login to ccd
-Use ProbateSolicitor1@gmail.com : password
+For a solicitor use ProbateSolicitor1@gmail.com : password  
+Alternatively, for a caseworker use  
+ProbateSolCW1@gmail.com : password
 
 ### Notes:
-You may need to forcibly remove any relevant images dbfirst to ensure the db init is correctly completed
+You may need to forcibly remove any relevant images db first to ensure the db init is correctly completed
 ```bash
 docker image rmi -f $(docker image ls -a -q)
 ```
+You may also find removing all ontainers helps
+```bash
+docker container rm -f $(docker container ls -a -q)
+```
+
 When the containers are restarted, ccd data has to be reloaded
 The user token expires approx every 4 hours
 
+### Mac users
+You will need to reconfigure your docker settings to allow at least 6.5Gb
 
 ## Hystrix
 

--- a/docker/docker-compose-with-ccd.yml
+++ b/docker/docker-compose-with-ccd.yml
@@ -381,7 +381,7 @@ services:
       - PROXY_DEFINITION_DATA=http://ccd-definition-store-api:4451/api/data
       - PROXY_DEFINITION_DISPLAY=http://ccd-definition-store-api:4451/api/display
       # this NEEDS to be your local ip address
-      - PROXY_PRINT_SERVICE=http://172.16.1.15:3100
+      - PROXY_PRINT_SERVICE=http://172.16.1.89:3100
       - PROXY_DOCUMENT_MANAGEMENT=http://document-management-store-api-gateway-web:8080
     ports:
       - 3453:3453

--- a/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
+++ b/src/main/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformer.java
@@ -57,6 +57,7 @@ public class CallbackResponseTransformer {
         CaseData caseData = callbackRequest.getCaseDetails().getData();
 
         ResponseCaseDataBuilder responseCaseData = this.getResponseCaseData(caseData);
+        responseCaseData.solsSOTNeedToUpdate(null);
         switch (pdfServiceTemplate) {
             case LEGAL_STATEMENT:
                 responseCaseData.solsLegalStatementDocument(ccdDocument);

--- a/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/transformer/CallbackResponseTransformerTest.java
@@ -179,6 +179,7 @@ public class CallbackResponseTransformerTest {
         assertEquals(DOC_BINARY_URL, callbackResponse.getData().getSolsLegalStatementDocument().getDocumentBinaryUrl());
         assertEquals(DOC_URL, callbackResponse.getData().getSolsLegalStatementDocument().getDocumentUrl());
         assertEquals(DOC_NAME, callbackResponse.getData().getSolsLegalStatementDocument().getDocumentFilename());
+        assertEquals(null, callbackResponse.getData().getSolsSOTNeedToUpdate());
     }
 
     @Test


### PR DESCRIPTION
Need to reset the 'needToUpdate' field to null, so that when the user returns to the question in review LS event, no preselection is made