### PR TITLE
PRO-2697: Updated tests to use relaxedHTTPSValidation, to avoid SSLHandshakeException.

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/businessvalidation/SolCcdServiceBusinessValidationTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/businessvalidation/SolCcdServiceBusinessValidationTests.java
@@ -150,6 +150,7 @@ public class SolCcdServiceBusinessValidationTests extends IntegrationTestBase {
 
     private void validatePostSuccess(String jsonFileName) {
         SerenityRest.given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile(jsonFileName))
                 .when().post("/case/validate")
@@ -170,6 +171,7 @@ public class SolCcdServiceBusinessValidationTests extends IntegrationTestBase {
 
     private void validatePostFailure(String jsonFileName, String errorMessage, Integer statusCode) {
         Response response = SerenityRest.given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile(jsonFileName))
                 .when().post("/case/validate")

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/checkyouranswers/SolCcdServiceCheckYourAnswersTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/checkyouranswers/SolCcdServiceCheckYourAnswersTests.java
@@ -101,7 +101,8 @@ public class SolCcdServiceCheckYourAnswersTests extends IntegrationTestBase {
 
     @Test
     public void verifyIncorrectInputReturns400() {
-        given().headers(utils.getHeaders())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeaders())
                 .body(utils.getJsonFromFile("incorrectInput.checkYourAnswersPayload.json")).
                 when().post("/case/validate").then().statusCode(400);
     }
@@ -129,6 +130,7 @@ public class SolCcdServiceCheckYourAnswersTests extends IntegrationTestBase {
     @Test
     public void validatePostRequestSuccessCYAForBeforeSignSOT() {
         Response response = given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("success.beforeSignSOT.checkYourAnswersPayload.json")).
                         when().post("/nextsteps/validate");
@@ -138,7 +140,8 @@ public class SolCcdServiceCheckYourAnswersTests extends IntegrationTestBase {
 
     @Test
     public void verifyStateChangeFromCYABeforeLegalStatement() {
-        given().headers(utils.getHeadersWithUserId())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("success.stateChange.checkYourAnswersPayload.json"))
                 .when().post("/nextsteps/validate")
                 .then().statusCode(200)
@@ -147,7 +150,8 @@ public class SolCcdServiceCheckYourAnswersTests extends IntegrationTestBase {
 
     @Test
     public void verifyStateChangeFromCYABeforeSigningSOT() {
-        given().headers(utils.getHeadersWithUserId())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("success.stateChange.beforeSOTcheckYourAnswersPayload.json"))
                 .when().post("/nextsteps/validate")
                 .then().statusCode(200)
@@ -169,6 +173,7 @@ public class SolCcdServiceCheckYourAnswersTests extends IntegrationTestBase {
 
     private void validatePostRequestSuccessForLegalStatement(String validationString) {
         Response response = given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("success.beforeLegalStatement.checkYourAnswersPayload.json")).
                         when().post("/case/validate");
@@ -179,7 +184,8 @@ public class SolCcdServiceCheckYourAnswersTests extends IntegrationTestBase {
 
 
     private void validatePostRequestFailureForLegalStatement(String oldString, String replacingString, String errorMsg) {
-        given().headers(utils.getHeaders())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeaders())
                 .body(replaceString(oldString, replacingString))
                 .when().post("/case/validate").then().statusCode(400)
                 .and().body("fieldErrors[0].field", equalToIgnoringCase(errorMsg))
@@ -198,6 +204,7 @@ public class SolCcdServiceCheckYourAnswersTests extends IntegrationTestBase {
         IntegrationTestBase.setEvidenceManagementUrlAsBaseUri();
         try {
             ValidatableResponse response2 = given()
+                    .relaxedHTTPSValidation()
                     .headers(utils.getHeadersWithUserId())
                     .when().get("/documents/" + documentId + "/binary")
                     .then().assertThat().statusCode(200);

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/fee/SolCcdServiceFeeTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/fee/SolCcdServiceFeeTests.java
@@ -55,6 +55,7 @@ public class SolCcdServiceFeeTests extends IntegrationTestBase {
 
     private void validatePostRequestSuccessForFee(String fileName, String param, String expectedValue) {
         given().headers(utils.getHeaders())
+                .relaxedHTTPSValidation()
                 .body(utils.getJsonFromFile(fileName))
                 .contentType(JSON)
                 .when().post("/nextsteps/validate")
@@ -65,6 +66,7 @@ public class SolCcdServiceFeeTests extends IntegrationTestBase {
 
     private void verifyIncorrectPostRequestReturns400(String fileName, String errorMessage) {
         given().headers(utils.getHeaders())
+                .relaxedHTTPSValidation()
                 .body(utils.getJsonFromFile(fileName))
                 .when().post("/nextsteps/validate").then()
                 .statusCode(400)

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/hardstops/SolCcdServiceDomicileHardStopTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/hardstops/SolCcdServiceDomicileHardStopTests.java
@@ -18,6 +18,7 @@ public class SolCcdServiceDomicileHardStopTests extends IntegrationTestBase {
     @Test
     public void validateDeceasedDetailWithoutDomicileHardStop() {
         given().headers(utils.getHeadersWithUserId())
+                .relaxedHTTPSValidation()
                 .body(utils.getJsonFromFile("success.deceasedDomicile.json"))
                 .when().post("/case/validate").then().statusCode(200)
                 .and().body("data.deceasedDomicileInEngWales", equalToIgnoringCase("Yes"));
@@ -26,6 +27,7 @@ public class SolCcdServiceDomicileHardStopTests extends IntegrationTestBase {
     @Test
     public void validateHardStopForDomicile() {
         given().headers(utils.getHeadersWithUserId())
+                .relaxedHTTPSValidation()
                 .body(utils.getJsonFromFile("hardStop.deceasedDomicile.json"))
                 .when().post("/case/validate").then().statusCode(200)
                 .and().body("data.state", equalToIgnoringCase("Stopped"))
@@ -35,6 +37,7 @@ public class SolCcdServiceDomicileHardStopTests extends IntegrationTestBase {
     @Test
     public void validateHardStopMessageForNoDomicile() {
         Response response = given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("hardStop.deceasedDomicile.json"))
                 .when().post("/case/stopConfirmation");

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/hardstops/SolCcdServiceExecutorHardStopTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/hardstops/SolCcdServiceExecutorHardStopTests.java
@@ -17,14 +17,16 @@ public class SolCcdServiceExecutorHardStopTests extends IntegrationTestBase {
 
     @Test
     public void validateDeceasedDetailWithoutDomicileHardStop() {
-        given().headers(utils.getHeadersWithUserId())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("success.executorWithoutHardStop.json"))
                 .when().post("/case/validate").then().statusCode(200);
     }
 
     @Test
     public void validateHardStopForDomicile() {
-        given().headers(utils.getHeadersWithUserId())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("hardStop.executor.json"))
                 .when().post("/case/validate").then().statusCode(200)
                 .and().body("data.state", equalToIgnoringCase("Stopped"))
@@ -35,6 +37,7 @@ public class SolCcdServiceExecutorHardStopTests extends IntegrationTestBase {
     @Test
     public void validateHardStopMessageForNoDomicile() {
         Response response = given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("hardStop.executor.json"))
                 .when().post("/case/stopConfirmation");

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/hardstops/SolCcdServiceWillUpdateHardStopTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/hardstops/SolCcdServiceWillUpdateHardStopTests.java
@@ -17,7 +17,8 @@ public class SolCcdServiceWillUpdateHardStopTests extends IntegrationTestBase {
 
     @Test
     public void validateWillUpdateWithoutHardStop() {
-        given().headers(utils.getHeadersWithUserId())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("success.willUpdate.json"))
                 .post("/case/validate").then().statusCode(200)
                 .and().body("data.willExists", equalToIgnoringCase("Yes"))
@@ -26,7 +27,8 @@ public class SolCcdServiceWillUpdateHardStopTests extends IntegrationTestBase {
 
     @Test
     public void validateHardStopForWillUpdate() {
-        given().headers(utils.getHeadersWithUserId())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("hardStop.noWillNotExists.json"))
                 .post("/case/validate").then().statusCode(200)
                 .and().body("data.state", equalToIgnoringCase("Stopped"))
@@ -36,7 +38,8 @@ public class SolCcdServiceWillUpdateHardStopTests extends IntegrationTestBase {
 
     @Test
     public void validateHardStopWithNoWillAccessOriginal() {
-        given().headers(utils.getHeadersWithUserId())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("hardStop.noWillAccessOriginal.json"))
                 .post("/case/validate").then().statusCode(200)
                 .and().body("data.state", equalToIgnoringCase("Stopped"))
@@ -46,7 +49,8 @@ public class SolCcdServiceWillUpdateHardStopTests extends IntegrationTestBase {
 
     @Test
     public void validateHardStopWithNoWillExistsAndNoWillAccessOriginal() {
-        given().headers(utils.getHeadersWithUserId())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("hardStop.noWillExists.noWillAccessOriginal.json"))
                 .post("/case/validate").then().statusCode(200)
                 .and().body("data.state", equalToIgnoringCase("Stopped"))
@@ -57,6 +61,7 @@ public class SolCcdServiceWillUpdateHardStopTests extends IntegrationTestBase {
     @Test
     public void validateHardMessageWithNoWillExists() {
         Response response = given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("hardStop.noWillNotExists.json"))
                 .post("/case/stopConfirmation");
@@ -67,6 +72,7 @@ public class SolCcdServiceWillUpdateHardStopTests extends IntegrationTestBase {
     @Test
     public void validateHardMessageWithNoOriginalWill() {
         Response response = given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("hardStop.noWillAccessOriginal.json"))
                 .post("/case/stopConfirmation");
@@ -77,6 +83,7 @@ public class SolCcdServiceWillUpdateHardStopTests extends IntegrationTestBase {
     @Test
     public void validateHardStopMessageWithNoOriginalWillAndNoWillExists() {
         Response response = given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("hardStop.noWillExists.noWillAccessOriginal.json"))
                 .post("/case/stopConfirmation");

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/nextsteps/SolCcdServiceNextStepsTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/nextsteps/SolCcdServiceNextStepsTests.java
@@ -97,6 +97,7 @@ public class SolCcdServiceNextStepsTests extends IntegrationTestBase {
 
     private void validatePostRequestSuccessForLegalStatement(String validationString) {
         Response response = given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("success.nextsteps.json"))
                 .post("/nextsteps/confirmation");
@@ -107,7 +108,8 @@ public class SolCcdServiceNextStepsTests extends IntegrationTestBase {
     }
 
     private void validatePostRequestFailureForLegalStatement(String oldString, String replacingString, String errorMsg) {
-        given().headers(utils.getHeaders())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeaders())
                 .body(replaceString(oldString, replacingString))
                 .post("/nextsteps/validate").then().statusCode(400)
                 .and().body("fieldErrors[0].field", equalToIgnoringCase(errorMsg))

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/printservice/SolCcdServicePrintServiceTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/printservice/SolCcdServicePrintServiceTests.java
@@ -17,6 +17,7 @@ public class SolCcdServicePrintServiceTests extends IntegrationTestBase {
     @Test
     public void verifySuccessForGetPrintTemplateDocuments() {
         Response response = SerenityRest.given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .body(utils.getJsonFromFile("success.printCaseDetails.json")).
                         when().post("/template/documents");
@@ -30,6 +31,7 @@ public class SolCcdServicePrintServiceTests extends IntegrationTestBase {
     @Test
     public void verifySolsTemplateDetails() {
         Response response = SerenityRest.given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .when().get("/template/case-details/sol");
 
@@ -62,6 +64,7 @@ public class SolCcdServicePrintServiceTests extends IntegrationTestBase {
     @Test
     public void verifyPaTemplateDetails() {
         Response response = SerenityRest.given()
+                .relaxedHTTPSValidation()
                 .headers(utils.getHeadersWithUserId())
                 .when().get("/template/case-details/pa");
 

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/serviceauth/SolCcdServiceServiceAuthTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/serviceauth/SolCcdServiceServiceAuthTests.java
@@ -12,7 +12,8 @@ public class SolCcdServiceServiceAuthTests extends IntegrationTestBase {
 
     @Test
     public void verifyThatWithCorrectAuthorizationWeReceiveSuccess() {
-        given().headers(utils.getHeaders())
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeaders())
                 .body(utils.getJsonFromFile("success.solicitorCreate.json"))
                 .post("/nextsteps/validate")
                 .then().assertThat().statusCode(200);
@@ -20,7 +21,8 @@ public class SolCcdServiceServiceAuthTests extends IntegrationTestBase {
 
     @Test
     public void verifyThatWithInCorrectAuthorizationWeReceive403() {
-        given().headers(utils.getHeaders("InvalidToken"))
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeaders("InvalidToken"))
                 .body(utils.getJsonFromFile("success.solicitorCreate.json"))
                 .post("/validate/addDeceasedDetails")
                 .then().assertThat().statusCode(403);
@@ -28,7 +30,8 @@ public class SolCcdServiceServiceAuthTests extends IntegrationTestBase {
 
     @Test
     public void verifyThatWithEmptyAuthorizationHeaderWeReceive403() {
-        given().headers(utils.getHeaders(""))
+        given().relaxedHTTPSValidation()
+                .headers(utils.getHeaders(""))
                 .body(utils.getJsonFromFile("success.solicitorCreate.json"))
                 .post("/validate/addDeceasedDetails")
                 .then().assertThat().statusCode(403);


### PR DESCRIPTION
Updated tests to use relaxedHTTPSValidation, to avoid SSLHandshakeException.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-2697


### Change description ###
 Updated tests to use relaxedHTTPSValidation, to avoid SSLHandshakeException.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
