### PR TITLE
PRO-2697: Updated test config, and gradle tasks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ dependencyCheck {
 }
 
 sourceSets {
-    smokeTest {
+    testSmoke {
         java {
             compileClasspath += main.output
             runtimeClasspath += main.output
@@ -108,7 +108,7 @@ sourceSets {
         }
         resources.srcDir file('src/smokeTest/resources')
     }
-    functionalTest {
+    testFunctional {
       java {
         compileClasspath += main.output
         runtimeClasspath += main.output
@@ -120,14 +120,14 @@ sourceSets {
 
 task smoke(type: Test) {
   description = "Runs Smoke Tests"
-  testClassesDirs = sourceSets.smokeTest.output.classesDirs
-  classpath = sourceSets.smokeTest.runtimeClasspath
+  testClassesDirs = sourceSets.testSmoke.output.classesDirs
+  classpath = sourceSets.testSmoke.runtimeClasspath
 }
 
 task functional(type: Test) {
   description = "Runs functional Tests"
-  testClassesDirs = sourceSets.functionalTest.output.classesDirs
-  classpath = sourceSets.functionalTest.runtimeClasspath
+  testClassesDirs = sourceSets.testFunctional.output.classesDirs
+  classpath = sourceSets.testFunctional.runtimeClasspath
   finalizedBy aggregate
 }
 
@@ -178,17 +178,17 @@ dependencies {
   testCompile group: 'org.pdfbox', name: 'com.springsource.org.pdfbox', version: '0.7.3'
   testCompile group: 'org.springframework.security', name: 'spring-security-test', version: '4.2.5.RELEASE'
 
-  smokeTestCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
-  smokeTestCompile sourceSets.main.runtimeClasspath
-  smokeTestCompile sourceSets.test.runtimeClasspath
+  testSmokeCompile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
+  testSmokeCompile sourceSets.main.runtimeClasspath
+  testSmokeCompile sourceSets.test.runtimeClasspath
 
-  functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-core', version: '1.5.2'
-  functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: '1.5.2'
-  functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: '1.5.2'
-  functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: '1.0.26'
-  functionalTestCompile group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.0'
-  functionalTestCompile sourceSets.main.runtimeClasspath
-  functionalTestCompile sourceSets.test.runtimeClasspath
+  testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-core', version: '1.5.2'
+  testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: '1.5.2'
+  testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: '1.5.2'
+  testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: '1.0.26'
+  testFunctionalCompile group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.0'
+  testFunctionalCompile sourceSets.main.runtimeClasspath
+  testFunctionalCompile sourceSets.test.runtimeClasspath
 }
 
 compileJava {

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/TestContextConfiguration.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/TestContextConfiguration.java
@@ -6,6 +6,6 @@ import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @ComponentScan("uk.gov.hmcts.probate.functional")
-@PropertySource("file:src/test/resources/application.properties")
+@PropertySource("application.properties")
 public class TestContextConfiguration {
 }

--- a/src/functionalTest/resources/application.properties
+++ b/src/functionalTest/resources/application.properties
@@ -1,0 +1,10 @@
+sol.ccd.service.base.url=${TEST_URL:http://localhost:4104}
+service.auth.provider.base.url=${SERVICE_AUTH_PROVIDER_BASE_URL:http://localhost:4502}
+user.auth.provider.oauth2.url=${USER_AUTH_PROVIDER_OAUTH2_URL:http://localhost:4501}
+evidence.management.url=${EVIDENCE_MANAGEMENT_URL:http://localhost:8080}
+service.name=PROBATE_BACKEND
+logging.level.root=DEBUG
+idam.oauth2.client.secret=OOOOOOOOOOOOOOOO
+idam.oauth2.client.id=ccd_gateway
+idam.oauth2.redirect_uri=http://localhost:3451/oauth2redirect
+user.id.url=${USER_ID:null}

--- a/src/smokeTest/java/uk/gov/hmcts/probate/SmokeTestConfiguration.java
+++ b/src/smokeTest/java/uk/gov/hmcts/probate/SmokeTestConfiguration.java
@@ -1,9 +1,0 @@
-package uk.gov.hmcts.probate;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
-
-@Configuration
-@PropertySource("file:src/test/resources/application.properties")
-public class SmokeTestConfiguration {
-}

--- a/src/smokeTest/java/uk/gov/hmcts/probate/SmokeTests.java
+++ b/src/smokeTest/java/uk/gov/hmcts/probate/SmokeTests.java
@@ -17,7 +17,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@ContextConfiguration(classes = SmokeTestConfiguration.class)
 public class SmokeTests {
 
     @Value("${test.instance.uri}")

--- a/src/smokeTest/resources/application.properties
+++ b/src/smokeTest/resources/application.properties
@@ -1,0 +1,1 @@
+test.instance.uri=${TEST_URL:http://localhost:4104}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,15 +1,2 @@
 probate.sol.ccd.port=4104
 s2s.enabled=false
-
-test.instance.uri=${TEST_URL:http://localhost:4104}
-
-sol.ccd.service.base.url=${TEST_URL:http://localhost:4104}
-service.auth.provider.base.url=${SERVICE_AUTH_PROVIDER_BASE_URL:http://localhost:4502}
-user.auth.provider.oauth2.url=${USER_AUTH_PROVIDER_OAUTH2_URL:http://localhost:4501}
-evidence.management.url=${EVIDENCE_MANAGEMENT_URL:http://localhost:8080}
-service.name=PROBATE_BACKEND
-logging.level.root=DEBUG
-idam.oauth2.client.secret=OOOOOOOOOOOOOOOO
-idam.oauth2.client.id=ccd_gateway
-idam.oauth2.redirect_uri=http://localhost:3451/oauth2redirect
-user.id.url=${USER_ID:null}


### PR DESCRIPTION
### Change description ###
- Renamed smokeTest and functionalTest gradle tasks to testSmoke and testFunctional, respectively
- Each test type now has its own application.properties file, rather than using the main test resources.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
