### PR TITLE
Ensured smoke test isn't loading the whole spring context.

### DIFF
--- a/src/smokeTest/java/uk/gov/hmcts/probate/smoke/SmokeTestConfiguration.java
+++ b/src/smokeTest/java/uk/gov/hmcts/probate/smoke/SmokeTestConfiguration.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.probate.smoke;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.PropertySource;
+
+@ComponentScan("uk.gov.hmcts.probate.smoke")
+@PropertySource("application.properties")
+public class SmokeTestConfiguration {
+}

--- a/src/smokeTest/java/uk/gov/hmcts/probate/smoke/SmokeTests.java
+++ b/src/smokeTest/java/uk/gov/hmcts/probate/smoke/SmokeTests.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.probate;
+package uk.gov.hmcts.probate.smoke;
 
 import io.restassured.RestAssured;
 import io.restassured.config.HttpClientConfig;
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -16,7 +15,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@ContextConfiguration(classes = {SmokeTestConfiguration.class})
 public class SmokeTests {
 
     @Value("${test.instance.uri}")


### PR DESCRIPTION
### Change description ###
Currently the smoke tests are failing because they are incorrectly trying to load the whole application spring context. This has now been fixed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
